### PR TITLE
Fix the DoradoHttpCheckHandler response

### DIFF
--- a/dorado/dorado-core-default/src/main/java/com/meituan/dorado/check/http/DoradoHttpCheckHandler.java
+++ b/dorado/dorado-core-default/src/main/java/com/meituan/dorado/check/http/DoradoHttpCheckHandler.java
@@ -65,7 +65,7 @@ public class DoradoHttpCheckHandler implements HttpCheckHandler {
          * http接口调用
          */
         if (path.startsWith(SERVICE_INVOKE_PREFIX.uri())) {
-            if (RpcRole.INVOKER == role) {
+            if (RpcRole.PROVIDER == role) {
                 String errorMsg = role + " not support service invoke";
                 logger.warn(errorMsg);
                 httpSender.sendErrorResponse(errorMsg);
@@ -194,5 +194,4 @@ public class DoradoHttpCheckHandler implements HttpCheckHandler {
     private synchronized void updateSupportReqs() {
         supportReqs = HttpURI.getSupportUriOfRole(role);
     }
-
 }

--- a/dorado/dorado-core/src/main/java/com/meituan/dorado/bootstrap/ServiceBootstrap.java
+++ b/dorado/dorado-core/src/main/java/com/meituan/dorado/bootstrap/ServiceBootstrap.java
@@ -34,9 +34,7 @@ public class ServiceBootstrap {
     public synchronized static void initHttpServer(RpcRole role) {
         // 默认启动http服务，作用于 服务自检
         HttpServerFactory httpServerFactory = ExtensionLoader.getExtension(HttpServerFactory.class);
-        if (httpServer == null) {
-            httpServer = httpServerFactory.buildServer(role);
-        }
+        httpServer = httpServerFactory.buildServer(role);
     }
 
     public static HttpServer getHttpServer() {

--- a/dorado/dorado-core/src/main/java/com/meituan/dorado/bootstrap/ServiceBootstrap.java
+++ b/dorado/dorado-core/src/main/java/com/meituan/dorado/bootstrap/ServiceBootstrap.java
@@ -19,6 +19,7 @@ import com.meituan.dorado.common.Constants;
 import com.meituan.dorado.common.RpcRole;
 import com.meituan.dorado.common.extension.ExtensionLoader;
 import com.meituan.dorado.common.util.CommonUtil;
+import com.meituan.dorado.rpc.handler.http.HttpHandler;
 import com.meituan.dorado.transport.http.HttpServer;
 import com.meituan.dorado.transport.http.HttpServerFactory;
 import org.apache.commons.lang3.StringUtils;
@@ -34,7 +35,18 @@ public class ServiceBootstrap {
     public synchronized static void initHttpServer(RpcRole role) {
         // 默认启动http服务，作用于 服务自检
         HttpServerFactory httpServerFactory = ExtensionLoader.getExtension(HttpServerFactory.class);
-        httpServer = httpServerFactory.buildServer(role);
+        if (httpServer == null) {
+            httpServer = httpServerFactory.buildServer(role);
+        } else if (httpServer.getHttpHandler() != null) {
+            HttpHandler httpHandler = httpServer.getHttpHandler();
+            RpcRole rpcRole = httpHandler.getRole();
+            if (rpcRole != null && rpcRole != role) {
+                rpcRole = RpcRole.MULTIROLE;
+            } else {
+                rpcRole = role;
+            }
+            httpHandler.setRole(rpcRole);
+        }
     }
 
     public static HttpServer getHttpServer() {

--- a/dorado/dorado-core/src/main/java/com/meituan/dorado/transport/http/AbstractHttpServer.java
+++ b/dorado/dorado-core/src/main/java/com/meituan/dorado/transport/http/AbstractHttpServer.java
@@ -31,8 +31,8 @@ public abstract class AbstractHttpServer implements HttpServer {
 
     private static final Logger logger = LoggerFactory.getLogger(AbstractHttpServer.class);
 
-    private static volatile boolean started;
-    private static volatile boolean destroyed;
+    private volatile boolean started;
+    private volatile boolean destroyed;
     private static final int PORT_BIND_RETRY_TIMES = 10;
 
     protected HttpHandler httpHandler;

--- a/dorado/dorado-core/src/test/java/com/meituan/dorado/mock/MockHttpServerFactory.java
+++ b/dorado/dorado-core/src/test/java/com/meituan/dorado/mock/MockHttpServerFactory.java
@@ -18,19 +18,24 @@ package com.meituan.dorado.mock;
 
 import com.meituan.dorado.common.RpcRole;
 import com.meituan.dorado.rpc.handler.http.HttpHandler;
+import com.meituan.dorado.transport.http.HttpSender;
 import com.meituan.dorado.transport.http.HttpServer;
 import com.meituan.dorado.transport.http.HttpServerFactory;
 
 import java.net.InetSocketAddress;
+import java.util.Map;
 
 public class MockHttpServerFactory implements HttpServerFactory {
 
     @Override
     public HttpServer buildServer(RpcRole rpcRole) {
-        return new MockHttpServer();
+        HttpServer httpServer = new MockHttpServer();
+        httpServer.getHttpHandler().setRole(rpcRole);
+        return httpServer;
     }
 
     public static class MockHttpServer implements HttpServer {
+        private HttpHandler httpHandler = new MockHttpHandler();
 
         @Override
         public InetSocketAddress getLocalAddress() {
@@ -39,7 +44,7 @@ public class MockHttpServerFactory implements HttpServerFactory {
 
         @Override
         public HttpHandler getHttpHandler() {
-            return null;
+            return httpHandler;
         }
 
         @Override
@@ -49,6 +54,24 @@ public class MockHttpServerFactory implements HttpServerFactory {
         @Override
         public boolean isStart() {
             return true;
+        }
+    }
+
+    public static class MockHttpHandler implements HttpHandler {
+        private RpcRole role;
+        @Override
+        public void handle(HttpSender httpSender, String uri, byte[] content, Map<String, String> headers) {
+
+        }
+
+        @Override
+        public RpcRole getRole() {
+            return role;
+        }
+
+        @Override
+        public void setRole(RpcRole role) {
+            this.role = role;
         }
     }
 }

--- a/dorado/dorado-test/dorado-test-integration/src/test/java/com/meituan/dorado/check/http/HttpCheckHandlerTest.java
+++ b/dorado/dorado-test/dorado-test-integration/src/test/java/com/meituan/dorado/check/http/HttpCheckHandlerTest.java
@@ -18,50 +18,193 @@ package com.meituan.dorado.check.http;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import com.google.common.collect.Sets;
+import com.meituan.dorado.bootstrap.ServiceBootstrap;
+import com.meituan.dorado.common.extension.ExtensionLoader;
+import com.meituan.dorado.transport.http.HttpServer;
+import org.junit.*;
+import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
+import java.net.ConnectException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class HttpCheckHandlerTest {
-    private static ClassPathXmlApplicationContext serverBeanFactory;
 
-    @BeforeClass
-    public static void init() {
-        serverBeanFactory = new ClassPathXmlApplicationContext("thrift/httpCheck/thrift-provider.xml");
-    }
+    private final String[] methods = new String[]{
+            "testMessage(com.meituan.dorado.test.thrift.apisuite.Message):Message",
+            "testBaseTypeReturnException():int",
+            "testMockProtocolException():void",
+            "testSubMessage(com.meituan.dorado.test.thrift.apisuite.SubMessage):SubMessage",
+            "testMessageList(java.util.List):List",
+            "testReturnNull():String",
+            "testIDLException():String",
+            "testNPE():String",
+            "testMultiIDLException():String",
+            "testTimeout():void",
+            "testVoid():void",
+            "testString(java.lang.String):String",
+            "testMessageMap(java.util.Map):Map",
+            "testStrMessage(java.lang.String, com.meituan.dorado.test.thrift.apisuite.SubMessage):SubMessage",
+            "testLong(long):long",
+            "multiParam(byte, int, long, double):Map"};
+    private int port;
+    private ClassPathXmlApplicationContext serverBeanFactory = null;
+    private ClassPathXmlApplicationContext clientBeanFactory = null;
 
-    @AfterClass
-    public static void destroy() {
-        serverBeanFactory.destroy();
+    @After
+    public void tearDown() throws Exception {
+        HttpServer httpServer = ServiceBootstrap.getHttpServer();
+        if (httpServer != null) {
+            httpServer.close();
+            Field field = ServiceBootstrap.class.getDeclaredField("httpServer");
+            field.setAccessible(true);
+            field.set(ServiceBootstrap.class, null);
+        }
+
+        {
+            Field field = ExtensionLoader.class.getDeclaredField("extensionMap");
+            Field field1 = ExtensionLoader.class.getDeclaredField("extensionListMap");
+            field.setAccessible(true);
+            field1.setAccessible(true);
+            ((Map)field.get(ExtensionLoader.class)).clear();
+            ((Map)field1.get(ExtensionLoader.class)).clear();
+        }
+
+        if (serverBeanFactory != null) {
+            serverBeanFactory.destroy();
+            serverBeanFactory = null;
+        }
+        if (clientBeanFactory != null) {
+            clientBeanFactory.destroy();
+            clientBeanFactory = null;
+        }
     }
 
     /**
      * 测试获取服务端基本信息
      */
     @Test
-    public void getServiceInfoTest() {
-        String url = "http://localhost:5080/service.info";
-        String result = HttpClientUtil.doGet(url, null);
+    public void onlySupportProviderHttpCheckHandlerWhenStartDoradoProvider() {
+         serverBeanFactory = new ClassPathXmlApplicationContext("thrift/httpCheck/thrift-provider.xml");
+        port = ServiceBootstrap.getHttpServer().getLocalAddress().getPort();
+        assertSuccessProviderHttpCheckHandler();
+        assertFailureConsumerHttpCheckHandler();
 
-        JsonNode providerInfo = null;
-        try {
-            providerInfo = new ObjectMapper().readTree(result);
-        } catch (IOException e) {
-            Assert.fail(e.getMessage());
-        }
-        Assert.assertEquals(4, providerInfo.size());
-        Assert.assertEquals("com.meituan.octo.dorado.server", providerInfo.get("appkey").asText());
-        Assert.assertEquals(2, providerInfo.get("serviceInfo").size());
-        Assert.assertEquals("9001", providerInfo.get("serviceInfo").get(0).get("port").asText());
 
-        Assert.assertEquals(1, providerInfo.get("serviceInfo").get(0).get("serviceIfaceInfos").size());
-        Assert.assertEquals("com.meituan.dorado.test.thrift.apisuite.TestSuite", providerInfo.get("serviceInfo").get(0).get("serviceIfaceInfos").get(0).get("serviceName").asText());
-        Assert.assertEquals("com.meituan.dorado.test.thrift.apisuite.TestSuite$Iface", providerInfo.get("serviceInfo").get(0).get("serviceIfaceInfos").get(0).get("ifaceName").asText());
-        Assert.assertEquals("com.meituan.dorado.test.thrift.apisuite.TestSuiteImpl", providerInfo.get("serviceInfo").get(0).get("serviceIfaceInfos").get(0).get("implName").asText());
     }
 
+    @Test
+    public void onlySupportAllHttpCheckHandlerWhenStartDoradoProviderAndConsumer() {
+         serverBeanFactory = new ClassPathXmlApplicationContext("thrift/httpCheck/thrift-provider.xml");
+         clientBeanFactory = new ClassPathXmlApplicationContext("thrift/httpCheck/thrift-consumer.xml");
+
+
+        port = ServiceBootstrap.getHttpServer().getLocalAddress().getPort();
+        assertSuccessProviderHttpCheckHandler();
+        assertSuccessConsumerHttpCheckHandler();
+
+    }
+
+    @Test
+    public void onlySupportConsumerHttpCheckHandlerWhenStartDoradoConsumer() {
+        try {
+            clientBeanFactory = new ClassPathXmlApplicationContext("thrift/httpCheck/thrift-consumer.xml");
+        } catch (Exception e) {
+            if (!(e.getCause().getCause().getCause() instanceof ConnectException)) {
+                throw e;
+            }
+        }
+
+
+        port = ServiceBootstrap.getHttpServer().getLocalAddress().getPort();
+        assertFailureProviderHttpCheckHandler();
+        assertSuccessConsumerHttpCheckHandler();
+    }
+
+    private void assertFailureProviderHttpCheckHandler() {
+        // 1. Assert the provider service.info path
+        {
+            String url = String.format("http://localhost:%d/service.info", port);
+            String result = HttpClientUtil.doGet(url, null);
+            Assert.assertEquals("{\"success\":false,\"result\":\"INVOKER not support the request. Support uri: []\"}", result);
+        }
+
+        // 2. Assert the provider method.info path
+        {
+            String url = String.format("http://localhost:%d/method.info", port);
+            String result = HttpClientUtil.doGet(url, null);
+            Assert.assertEquals("{\"success\":false,\"result\":\"INVOKER not support the request. Support uri: []\"}", result);
+        }
+
+    }
+
+    private void assertSuccessProviderHttpCheckHandler() {
+        // 1. Assert the provider service.info path
+        {
+            String url = String.format("http://localhost:%d/service.info", port);
+            String result = HttpClientUtil.doGet(url, null);
+
+            JsonNode providerInfo = null;
+            try {
+                providerInfo = new ObjectMapper().readTree(result);
+            } catch (IOException e) {
+                Assert.fail(e.getMessage());
+            }
+            Assert.assertEquals(4, providerInfo.size());
+            Assert.assertEquals("com.meituan.octo.dorado.server", providerInfo.get("appkey").asText());
+            Assert.assertEquals(2, providerInfo.get("serviceInfo").size());
+            Assert.assertEquals("9001", providerInfo.get("serviceInfo").get(0).get("port").asText());
+
+            Assert.assertEquals(1, providerInfo.get("serviceInfo").get(0).get("serviceIfaceInfos").size());
+            Assert.assertEquals("com.meituan.dorado.test.thrift.apisuite.TestSuite", providerInfo.get("serviceInfo").get(0).get("serviceIfaceInfos").get(0).get("serviceName").asText());
+            Assert.assertEquals("com.meituan.dorado.test.thrift.apisuite.TestSuite$Iface", providerInfo.get("serviceInfo").get(0).get("serviceIfaceInfos").get(0).get("ifaceName").asText());
+            Assert.assertEquals("com.meituan.dorado.test.thrift.apisuite.TestSuiteImpl", providerInfo.get("serviceInfo").get(0).get("serviceIfaceInfos").get(0).get("implName").asText());
+        }
+
+        // 2. Assert the provider method.info path
+        {
+            String url = String.format("http://localhost:%d/method.info", port);
+            String result = HttpClientUtil.doGet(url, null);
+
+            JsonNode methodInfo = null;
+            try {
+                methodInfo = new ObjectMapper().readTree(result);
+            } catch (IOException e) {
+                Assert.fail(e.getMessage());
+            }
+            Assert.assertEquals(3, methodInfo.size());
+            Assert.assertEquals("com.meituan.octo.dorado.server", methodInfo.get("appkey").asText());
+            Assert.assertEquals(1, methodInfo.get("serviceMethods").size());
+            JsonNode serviceMethod = methodInfo.get("serviceMethods").get(0);
+            Assert.assertEquals("com.meituan.dorado.test.thrift.apisuite.TestSuite", serviceMethod.get("serviceName").asText());
+
+            System.out.println(serviceMethod.get("methods"));
+            Assert.assertEquals(16, serviceMethod.get("methods").size());
+            final Set<String> expectedMethods = Sets.newHashSet(methods);
+            for (JsonNode node : serviceMethod.get("methods")) {
+                Assert.assertTrue(expectedMethods.remove(node.asText()));
+            }
+            Assert.assertTrue(expectedMethods.isEmpty());
+        }
+
+    }
+
+    private void assertFailureConsumerHttpCheckHandler() {
+        String url = String.format("http://localhost:%d/invoker", port);
+        String result = HttpClientUtil.doGet(url, null);
+        Assert.assertEquals("{\"success\":false,\"result\":\"PROVIDER not support service invoke\"}", result);
+    }
+
+    private void assertSuccessConsumerHttpCheckHandler() {
+        String url = String.format("http://localhost:%d/invoker", port);
+        String result = HttpClientUtil.doGet(url, null);
+        Assert.assertEquals("接口请求支持中", result);
+    }
 }

--- a/dorado/dorado-test/dorado-test-integration/src/test/resources/thrift/httpCheck/thrift-consumer.xml
+++ b/dorado/dorado-test/dorado-test-integration/src/test/resources/thrift/httpCheck/thrift-consumer.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2018 Meituan Dianping. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <bean id="oriThriftClient" class="com.meituan.dorado.config.service.spring.ReferenceBean" destroy-method="destroy">
+        <property name="serviceInterface" value="com.meituan.dorado.test.thrift.apisuite.TestSuite"/>
+        <property name="timeout" value="1000"/>
+        <property name="appkey" value="com.meituan.octo.dorado.client"/>
+        <property name="remoteAppkey" value="com.meituan.octo.dorado.server"/>
+        <property name="directConnAddress" value="localhost:9001"/>
+        <property name="clusterPolicy" value="failfast"/>
+    </bean>
+
+    <bean id="octoProtocolClient" class="com.meituan.dorado.config.service.spring.ReferenceBean" destroy-method="destroy">
+        <property name="serviceInterface" value="com.meituan.dorado.test.thrift.apisuite.TestSuite"/>
+        <property name="timeout" value="1000"/>
+        <property name="appkey" value="com.meituan.octo.dorado.client"/>
+        <property name="remoteAppkey" value="com.meituan.octo.dorado.server"/>
+        <property name="directConnAddress" value="localhost:9001"/>
+        <property name="remoteOctoProtocol" value="true"/>
+        <property name="clusterPolicy" value="failfast"/>
+    </bean>
+
+</beans>


### PR DESCRIPTION
修复 Dorado HTTP 响应问题

### 背景
在测试 Dorado HTTP 响应时，发现结果与预期不符。在同一进程中同时初始化 Dorado 的 Invoker 和 Provider，~/service.info 接口启动后可能会返回 “PROVIDER not support service invoke”。

### 问题原因
Dorado 的 HttpServer 初始化异常。原因是 `ServiceBootstrap.initHttpServer()` 仅支持初始化一种 Rpc 角色。
```java
public synchronized static void initHttpServer(RpcRole role) {
         // 默认启动 http服务，作用于 服务自检
        HttpServerFactory httpServerFactory = ExtensionLoader.getExtension(HttpServerFactory.class);
        if (httpServer == null) {
            httpServer = httpServerFactory.buildServer(role);
        }
}
```

### 修复方案
如果 httpServer 已经初始化完成，那么重新设置 HttpServer.httpHandler.role 的字段值，以解决 HttpServer 仅支持初始化一种 Rpc 角色问题。
```java
public synchronized static void initHttpServer(RpcRole role) {
         // 默认启动 http服务，作用于 服务自检
         HttpServerFactory httpServerFactory = ExtensionLoader.getExtension(HttpServerFactory.class);
         if (httpServer == null) {
             httpServer = httpServerFactory.buildServer(role);
         } else if (httpServer.getHttpHandler() != null) {
             HttpHandler httpHandler = httpServer.getHttpHandler();
             RpcRole rpcRole = httpHandler.getRole();
             if (rpcRole != null && rpcRole != role) {
                 rpcRole = RpcRole.MULTIROLE;
             } else {
                 rpcRole = role;
             }
             httpHandler.setRole(rpcRole);
         }
     }
```
